### PR TITLE
 make the extension relocatable during installation

### DIFF
--- a/sql/check_access.sql
+++ b/sql/check_access.sql
@@ -388,6 +388,6 @@ $$ language sql;
 
 grant execute on function @extschema@.my_privs_sys() to public;
 
-create or replace view @extschema@.my_privs_sys as select * from my_privs_sys();
+create or replace view @extschema@.my_privs_sys as select * from @extschema@.my_privs_sys();
 grant select on @extschema@.my_privs_sys to public;
 


### PR DESCRIPTION
Adding of "@extschema@" for SQL objects in order.
Currently, if extension is installed in an another schema of public, we need to set search_path in order to make it working fine.
With using "@extschema@", we don't need to set search_path.